### PR TITLE
default contribution PRs to master

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -25,6 +25,8 @@
     "scottwhi@microsoft.com"
   ],
   "branches_to_filter": [],
+  "git_repository_url_open_to_public_contributors": "https://github.com/MicrosoftDocs/BingAds-docs",
+  "git_repository_branch_open_to_public_contributors": "master",
   "skip_source_output_uploading": false,
   "need_preview_pull_request": false,
   "contribution_branch_mappings": {},


### PR DESCRIPTION
Set the default branch for external PRs to master instead of live.